### PR TITLE
reactor(docs): add formatting fix

### DIFF
--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -418,10 +418,17 @@ prefixed_base58check = "9bXiEd8boQVhq7WddEcERUL5tyyJVFYdU8th3HfbNXK3Yw6GRXh"
 ## 4.8 References
 
 1. <a id="reference-1"> https://web.cs.ucdavis.edu/~rogaway/papers/ad.pdf</a>
+
 2. <a id="reference-2"> https://www.secg.org/sec2-v2.pdf</a>
+
 3. <a id="reference-3"> https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki</a>
+
 4. <a id="reference-4"> https://tools.ietf.org/html/rfc8439</a>
+
 5. <a id="reference-5"> https://www.ietf.org/rfc/rfc2104.txt</a>
+
 6. <a id="reference-6"> https://tools.ietf.org/html/rfc5869</a>
+
 7. <a id="reference-7"> https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki</a>
+
 ```


### PR DESCRIPTION
Add proper formating to the markdown file to allow accurate parsing of the reference items